### PR TITLE
session save only occurs if more than one window (?)

### DIFF
--- a/doc/autosess.txt
+++ b/doc/autosess.txt
@@ -19,10 +19,11 @@ Start Vim without file arguments to automatically load previous session for
 current directory. This make easier work with complex projects - just chdir to
 project directory and start `vim`.
 
-When you quit from Vim, if there are more than one open tab/window, session
-will be automatically saved. This let you edit single files in same directory
-without breaking your saved session. (Quickfix and vimdiff's windows are
-ignored.)
+When you quit from Vim, if there is at least one open window, session will be
+automatically saved (delete/wipe all buffers before exiting to cause
+previously created session to be deleted). This lets you edit files in the
+same directory (by specifying them on command-line) without breaking your
+saved session.  (Quickfix and vimdiff's windows are ignored.)
 
 If you quit from Vim with no open files, session will be deleted. This let you
 start usual empty Vim in this directory next time.

--- a/plugin/autosess.vim
+++ b/plugin/autosess.vim
@@ -50,10 +50,25 @@ function AutosessUpdate()
 	if !isdirectory(expand(g:autosess_dir))
 		call mkdir(expand(g:autosess_dir), 'p', 0700)
 	endif
-	if tabpagenr('$') > 1 || (s:WinNr() > 1 && !&diff)
-		execute 'mksession! ' . fnameescape(v:this_session)
-	elseif winnr('$') == 1 && line('$') == 1 && col('$') == 1
+
+	if s:OnlyOneEmptyWindowRemains()
+		" allow user to delete session by deleting all buffers
 		call delete(v:this_session)
+	elseif (s:WinNr() >= 1 && !&diff)
+		execute 'mksession! ' . fnameescape(v:this_session)
+	endif
+endfunction
+
+function s:OnlyOneEmptyWindowRemains()
+	if (
+		\ tabpagenr('$') == 1
+		\ && winnr('$') == 1
+		\ && line('$') == 1
+		\ && col('$') == 1
+	\)
+		return 1
+	else
+		return 0
 	endif
 endfunction
 


### PR DESCRIPTION
While trying to ascertain why this plugin wasn't working for me, I came across this code in `AutosessUpdate()` which determines whether we execute `:mksession` upon `VimLeave`:

```
if tabpagenr('$') > 1 || (s:WinNr() > 1 && !&diff)
execute 'mksession! ' . fnameescape(v:this_session)
```

My understanding of this code is that we only save the session if (1) there is more than one tab, OR (2a) we are not in diffmode, AND (2b) there is more than one [non-quickfix] window.

Why this restriction? It seems to make perfectly good sense to save session options when editing a single file (with a single window).  In particular I want to use `vim-plugin-autosess` to remember my filetype settings and not have to embed modelines everywhere.

Is there some non-obvious reason for this restriction (must have more than one window) that I'm not understanding?
